### PR TITLE
Scaffold main template structure

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,5 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, sans-serif;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,37 +1,6 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
-import AnimalsList from './components/AnimalsList'
+import MainPage from "./pages/MainPage";
+import "./App.css";
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-      <AnimalsList />
-    </>
-  )
+export default function App() {
+  return <MainPage />;
 }
-
-export default App

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,0 +1,6 @@
+.footer {
+  background-color: #f5f5f5;
+  text-align: center;
+  padding: 2rem 0;
+  margin-top: 2rem;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+import "./Footer.css";
+
+export default function Footer() {
+  return (
+    <footer className="footer">
+      <p>&copy; 2025 Pet Rescue. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,25 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: #fff;
+}
+
+.header-logo img {
+  height: 40px;
+}
+
+.header-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.header-nav a {
+  text-decoration: none;
+  color: #333;
+  font-weight: 500;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,20 @@
+import "./Header.css";
+
+const logoUrl = "https://placehold.co/120x40?text=Logo";
+
+export default function Header() {
+  return (
+    <header className="header">
+      <div className="header-logo">
+        <img src={logoUrl} alt="Pet Rescue logo" />
+      </div>
+      <nav className="header-nav">
+        <ul>
+          <li><a href="#">Home</a></li>
+          <li><a href="#">Adopt</a></li>
+          <li><a href="#">Donate</a></li>
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/src/components/PetCard.css
+++ b/src/components/PetCard.css
@@ -1,0 +1,10 @@
+.pet-card {
+  width: 200px;
+  text-align: center;
+}
+
+.pet-card img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+}

--- a/src/components/PetCard.tsx
+++ b/src/components/PetCard.tsx
@@ -1,0 +1,15 @@
+import "./PetCard.css";
+
+type PetCardProps = {
+  name: string;
+  image: string;
+};
+
+export default function PetCard({ name, image }: PetCardProps) {
+  return (
+    <div className="pet-card">
+      <img src={image} alt={name} />
+      <h3>{name}</h3>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,11 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+body {
+  margin: 0;
+  background-color: #ffffff;
+  color: #333;
+  font-family: system-ui, sans-serif;
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  color: inherit;
+  text-decoration: none;
 }

--- a/src/pages/MainPage.css
+++ b/src/pages/MainPage.css
@@ -1,0 +1,18 @@
+.hero {
+  height: 300px;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  text-align: center;
+}
+
+.pets {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,0 +1,33 @@
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import PetCard from "../components/PetCard";
+import "./MainPage.css";
+
+const heroUrl = "https://placekitten.com/1920/490";
+const petImg = "https://placekitten.com/263/180";
+
+export default function MainPage() {
+  const pets = [
+    { name: "Fluffy", image: petImg },
+    { name: "Spot", image: petImg },
+    { name: "Whiskers", image: petImg },
+  ];
+
+  return (
+    <>
+      <Header />
+      <section className="hero" style={{ backgroundImage: `url(${heroUrl})` }}>
+        <div className="hero-content">
+          <h1>Welcome to Pet Rescue</h1>
+          <p>Find your new best friend today.</p>
+        </div>
+      </section>
+      <section className="pets">
+        {pets.map((pet) => (
+          <PetCard key={pet.name} {...pet} />
+        ))}
+      </section>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold main layout with reusable header, footer, and pet card components
- style sections with dedicated CSS files and TypeScript components
- replace local image assets with remote placeholders to keep repository text-only

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac92200578832cba2e4eaa420a4b2c