### PR TITLE
Revamp main page layout and branding

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -6,10 +6,6 @@
   background-color: #fff;
 }
 
-.header-logo img {
-  height: 40px;
-}
-
 .header-nav ul {
   list-style: none;
   display: flex;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,11 +1,11 @@
 import "./Header.css";
-import logoUrl from "../../assets/logo.png";
+import logoUrl from "../../assets/originals/logo_sugarloaf.jpeg";
 
 export default function Header() {
   return (
     <header className="header">
       <div className="header-logo">
-        <img src={logoUrl} alt="Pet Rescue logo" />
+        <img src={logoUrl} alt="Sugarloaf Mountain Ranch logo" />
       </div>
       <nav className="header-nav">
         <ul>

--- a/src/components/PetCard/PetCard.css
+++ b/src/components/PetCard/PetCard.css
@@ -5,6 +5,7 @@
 
 .pet-card img {
   width: 100%;
-  height: auto;
+  height: 150px;
+  object-fit: cover;
   border-radius: 4px;
 }

--- a/src/components/TestimonialForm/TestimonialForm.css
+++ b/src/components/TestimonialForm/TestimonialForm.css
@@ -1,11 +1,16 @@
 .testimonial-form {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  max-width: 400px;
+  max-width: 800px;
 }
 
 .testimonial-form div {
   display: flex;
   flex-direction: column;
+  flex: 1 1 150px;
+}
+
+.testimonial-form button {
+  align-self: flex-start;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
-  background-color: #ffffff;
-  color: #333;
+  background-color: #7b4a2f;
+  color: #fff;
   font-family: system-ui, sans-serif;
 }
 

--- a/src/pages/MainPage.css
+++ b/src/pages/MainPage.css
@@ -15,14 +15,17 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  align-items: flex-end;
   gap: 1rem;
   padding: 2rem;
 }
 
 .testimonials {
-  padding: 2rem;
+  padding: 1rem;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #333;
 }

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -10,11 +10,15 @@ export default function MainPage() {
       <Header />
       <section className="hero">
         <div className="hero-content">
-          <h1>Welcome to Pet Rescue</h1>
-          <p>Find your new best friend today.</p>
+          <h1>Sugarloaf Mountain Ranch, inc.</h1>
+          <p>501c3 Non-Profit Farm Animal Rescue and Sanctuary</p>
         </div>
       </section>
       <PetCarousel />
+      <section className="testimonials">
+        <h2>Share your story</h2>
+        <TestimonialForm />
+      </section>
       <Footer />
     </>
   );


### PR DESCRIPTION
## Summary
- style index to show brown background with white text
- update main page hero title and subtitle for Sugarloaf Mountain Ranch
- reorder layout so pet carousel appears above a compact testimonial form and standardize pet card image sizes
- display Sugarloaf logo in header without forced scaling

## Testing
- ❌ `npm test` (vitest not installed)
- ❌ `npm run lint` (missing @eslint/js dependency)

------
https://chatgpt.com/codex/tasks/task_e_68accf9ed308832c928b639ea8d9d315