### PR TITLE
Add animal dropdown to testimonial form

### DIFF
--- a/src/components/TestimonialForm/TestimonialForm.css
+++ b/src/components/TestimonialForm/TestimonialForm.css
@@ -9,3 +9,8 @@
   display: flex;
   flex-direction: column;
 }
+
+.animal-photo {
+  max-width: 150px;
+  margin-top: 0.5rem;
+}

--- a/src/components/TestimonialForm/TestimonialForm.test.tsx
+++ b/src/components/TestimonialForm/TestimonialForm.test.tsx
@@ -5,6 +5,13 @@ import TestimonialForm from "./TestimonialForm";
 
 describe("TestimonialForm", () => {
   it("submits testimonial data", async () => {
+    vi.spyOn(api, "fetchAnimals").mockResolvedValue([
+      {
+        name: "Spot",
+        species: "dog",
+        photoUrl: "http://example.com/pet.jpg",
+      },
+    ]);
     const submit = vi
       .spyOn(api, "submitTestimonial")
       .mockResolvedValue({ id: "1" });
@@ -17,11 +24,8 @@ describe("TestimonialForm", () => {
     fireEvent.change(screen.getByLabelText(/Details/i), {
       target: { value: "Great service" },
     });
-    fireEvent.change(screen.getByLabelText(/Animal Name/i), {
+    fireEvent.change(await screen.findByLabelText(/Animal/i), {
       target: { value: "Spot" },
-    });
-    fireEvent.change(screen.getByLabelText(/Animal Photo URL/i), {
-      target: { value: "http://example.com/pet.jpg" },
     });
     fireEvent.click(screen.getByText("Submit"));
 

--- a/src/components/TestimonialForm/TestimonialForm.tsx
+++ b/src/components/TestimonialForm/TestimonialForm.tsx
@@ -1,14 +1,21 @@
-import { useState } from "react";
-import { submitTestimonial } from "../../lib/api";
+import { useEffect, useState } from "react";
+import { fetchAnimals, submitTestimonial, Animal } from "../../lib/api";
 import "./TestimonialForm.css";
 
 export default function TestimonialForm() {
   const [name, setName] = useState("");
   const [anonymous, setAnonymous] = useState(false);
   const [text, setText] = useState("");
+  const [animals, setAnimals] = useState<Animal[]>([]);
   const [animalName, setAnimalName] = useState("");
   const [animalPhoto, setAnimalPhoto] = useState("");
   const [status, setStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchAnimals()
+      .then(setAnimals)
+      .catch((e) => setStatus(e.message));
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -67,21 +74,26 @@ export default function TestimonialForm() {
       </div>
       <div>
         <label>
-          Animal Name:
-          <input
+          Animal:
+          <select
             value={animalName}
-            onChange={(e) => setAnimalName(e.target.value)}
-          />
+            onChange={(e) => {
+              const selected = animals.find((a) => a.name === e.target.value);
+              setAnimalName(selected?.name || "");
+              setAnimalPhoto(selected?.photoUrl || "");
+            }}
+          >
+            <option value="">Select an animal</option>
+            {animals.map((a) => (
+              <option key={a.name} value={a.name}>
+                {a.name}
+              </option>
+            ))}
+          </select>
         </label>
-      </div>
-      <div>
-        <label>
-          Animal Photo URL:
-          <input
-            value={animalPhoto}
-            onChange={(e) => setAnimalPhoto(e.target.value)}
-          />
-        </label>
+        {animalPhoto && (
+          <img src={animalPhoto} alt={animalName} className="animal-photo" />
+        )}
       </div>
       <button type="submit">Submit</button>
       {status && <p>{status}</p>}

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -3,7 +3,7 @@ import { API_BASE, fetchAnimals, submitTestimonial, TestimonialPayload } from '.
 
 describe('fetchAnimals', () => {
   it('returns animals when response is ok', async () => {
-    const animals = [{ name: 'Tom', species: 'cat' }];
+    const animals = [{ name: 'Tom', species: 'cat', photoUrl: 'tom.jpg' }];
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue(animals),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,16 @@
 export const API_BASE = import.meta.env.VITE_API_BASE ?? "http://127.0.0.1:8000/api";
 
+export type Animal = {
+  name: string;
+  species: string;
+  description?: string;
+  photoUrl: string;
+};
+
 export async function fetchAnimals() {
   const res = await fetch(`${API_BASE}/animals`);
   if (!res.ok) throw new Error(`Failed: ${res.status}`);
-  return res.json() as Promise<{ name: string; species: string; description?: string }[]>;
+  return res.json() as Promise<Animal[]>;
 }
 
 export type TestimonialPayload = {


### PR DESCRIPTION
## Summary
- extend API and tests to include animal photos
- replace testimonial animal text inputs with dropdown populated from API and preview image
- style testimonial form to display selected animal photo

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68acd02af5ec832cb42e9324594bd229