### PR TITLE
feat: add placeholder site data

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,9 +1,16 @@
 import "./Footer.css";
+import placeholderData from "../../lib/placeholderData";
 
-export default function Footer() {
+export interface FooterProps {
+  copyright?: string;
+}
+
+export default function Footer({
+  copyright = placeholderData.footer.copyright,
+}: FooterProps) {
   return (
     <footer className="footer">
-      <p>&copy; 2025 Pet Rescue. All rights reserved.</p>
+      <p>{copyright}</p>
     </footer>
   );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,13 +1,22 @@
 import "./Header.css";
+import placeholderData, { type NavItem } from "../../lib/placeholderData";
 
-export default function Header() {
+export interface HeaderProps {
+  navItems?: NavItem[];
+}
+
+export default function Header({
+  navItems = placeholderData.header.navItems,
+}: HeaderProps) {
   return (
     <header className="header">
       <nav className="header-nav">
         <ul>
-          <li><a href="#">Home</a></li>
-          <li><a href="#">Adopt</a></li>
-          <li><a href="#">Donate</a></li>
+          {navItems.map((item) => (
+            <li key={item.label}>
+              <a href={item.href}>{item.label}</a>
+            </li>
+          ))}
         </ul>
       </nav>
     </header>

--- a/src/components/PetCard/PetCard.tsx
+++ b/src/components/PetCard/PetCard.tsx
@@ -1,11 +1,15 @@
 import "./PetCard.css";
+import placeholderData from "../../lib/placeholderData";
 
-type PetCardProps = {
-  name: string;
-  image: string;
-};
+export interface PetCardProps {
+  name?: string;
+  image?: string;
+}
 
-export default function PetCard({ name, image }: PetCardProps) {
+export default function PetCard({
+  name = placeholderData.petCard.name,
+  image = placeholderData.petCard.image,
+}: PetCardProps) {
   return (
     <div className="pet-card">
       <img src={image} alt={name} />

--- a/src/lib/placeholderData.ts
+++ b/src/lib/placeholderData.ts
@@ -1,0 +1,44 @@
+export interface NavItem {
+  href: string;
+  label: string;
+}
+
+export interface SiteData {
+  header: {
+    navItems: NavItem[];
+  };
+  footer: {
+    copyright: string;
+  };
+  hero: {
+    title: string;
+    subtitle: string;
+  };
+  petCard: {
+    name: string;
+    image: string;
+  };
+}
+
+const placeholderData: SiteData = {
+  header: {
+    navItems: [
+      { href: '#', label: 'Home' },
+      { href: '#', label: 'Adopt' },
+      { href: '#', label: 'Donate' },
+    ],
+  },
+  footer: {
+    copyright: '\u00A9 2025 Pet Rescue. All rights reserved.',
+  },
+  hero: {
+    title: 'Sugarloaf Mountain Ranch, inc.',
+    subtitle: '501c3 Non-Profit Farm Animal Rescue and Sanctuary',
+  },
+  petCard: {
+    name: 'Mittens',
+    image: '/placeholder.png',
+  },
+};
+
+export default placeholderData;

--- a/tests/components/Footer/Footer.test.tsx
+++ b/tests/components/Footer/Footer.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Footer from '@/components/Footer/Footer';
+import placeholderData from '@/lib/placeholderData';
+
+describe('Footer', () => {
+  it('falls back to placeholder copyright', () => {
+    render(<Footer />);
+    expect(screen.getByText(placeholderData.footer.copyright)).toBeInTheDocument();
+  });
+});

--- a/tests/components/Header/Header.test.tsx
+++ b/tests/components/Header/Header.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Header from '@/components/Header/Header';
+import placeholderData from '@/lib/placeholderData';
+
+describe('Header', () => {
+  it('falls back to placeholder navigation', () => {
+    render(<Header />);
+    placeholderData.header.navItems.forEach((item) => {
+      expect(screen.getByRole('link', { name: item.label })).toHaveAttribute('href', item.href);
+    });
+  });
+});

--- a/tests/components/PetCard/PetCard.test.tsx
+++ b/tests/components/PetCard/PetCard.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import PetCard from '@/components/PetCard/PetCard';
+import placeholderData from '@/lib/placeholderData';
 
 describe('PetCard', () => {
   it('renders name and image', () => {
@@ -8,5 +9,16 @@ describe('PetCard', () => {
     const img = screen.getByRole('img', { name: /fluffy/i });
     expect(img).toHaveAttribute('src', '/fluffy.png');
     expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Fluffy');
+  });
+
+  it('falls back to placeholder data', () => {
+    render(<PetCard />);
+    const img = screen.getByRole('img', {
+      name: placeholderData.petCard.name,
+    });
+    expect(img).toHaveAttribute('src', placeholderData.petCard.image);
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+      placeholderData.petCard.name,
+    );
   });
 });

--- a/tests/components/PetCarousel/PetCarousel.test.tsx
+++ b/tests/components/PetCarousel/PetCarousel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { vi } from "vitest";
 import PetCarousel from "@/components/PetCarousel/PetCarousel";
 
@@ -9,7 +9,9 @@ describe("PetCarousel", () => {
     const images = screen.getAllByRole("img");
     expect(images).toHaveLength(3);
     const firstSrc = images[0].getAttribute("src");
-    vi.advanceTimersByTime(15000);
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
     const newSrc = screen.getAllByRole("img")[0].getAttribute("src");
     expect(newSrc).not.toBe(firstSrc);
     vi.useRealTimers();


### PR DESCRIPTION
## Summary
- add placeholder site data for header, footer, hero, and pet card
- default Header, Footer, and PetCard to placeholder content
- ensure PetCarousel test uses act and add fallback tests

## Testing
- `npm test`
- `npm run lint` *(fails: baseName is assigned a value but never used, candidate is never reassigned, pad is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_b_68c5b966173c8322b63ec3f859b74cea